### PR TITLE
Make build_package() more robust

### DIFF
--- a/R/build.R
+++ b/R/build.R
@@ -4,23 +4,40 @@
 build_package <- function(path, tmpdir) {
 
   dir.create(tmpdir)
-  file.copy(path, tmpdir, recursive = TRUE)
 
-  ## If not a tar.gz, build it. Otherwise just leave it as it is.
+  ## If not a tar.gz, build it. Otherwise just leave it as it is
+  ## (but sanitize the file name).
   if (file.info(path)$isdir) {
+    file.copy(path, tmpdir, recursive = TRUE)
+
     build_status <- with_dir(
       tmpdir,
       rcmd_safe("build", basename(path))
     )
     unlink(file.path(tmpdir, basename(path)), recursive = TRUE)
     report_system_error("Build failed", build_status)
+
+    ## This assumes that the built package doesn't contain a .tar.gz file
+    ## on its root.
+    target_path <- file.path(
+      tmpdir,
+      list.files(tmpdir, pattern = "\\.tar\\.gz$")
+    )
+  } else {
+    target_path <- file.path(tmpdir, sanitize_tar_gz_name(basename(path)))
+    file.copy(path, target_path)
   }
 
-  ## replace previous handler, no need to clean up any more
-  on.exit(NULL)
+  target_path
+}
 
-  file.path(
-    tmpdir,
-    list.files(tmpdir, pattern = "\\.tar\\.gz$")
+sanitize_tar_gz_name <- function(name) {
+  pkg_name_rx <- "[a-zA-Z][a-zA-Z0-9.]*[a-zA-Z0-9]"
+  pkg_version_rx <- "[0-9.-]+"
+  extension_rx <- "\\.tar\\.gz"
+  gsub(
+    paste0("^(", pkg_name_rx, "_", pkg_version_rx, ").*(", extension_rx, ")$"),
+    "\\1\\2",
+    name
   )
 }


### PR DESCRIPTION
against `.tar.gz` file names that contain the platform or other arbitrary text. This was necessary to make revdepcheck work on my Linux system. I do wonder why crancache stores platform-specific files in `src/contrib` .

Happy to add a test for the `sanitize...()` function.