### PR TITLE
Fix parse_results()

### DIFF
--- a/R/background.R
+++ b/R/background.R
@@ -133,7 +133,7 @@ rcc_parse_results <- function(self, private) {
     stdout =  paste(private$cstdout, collapse = "\n"),
     stderr =  paste(private$cstderr, collapse = "\n"),
     status =  self$get_exit_status(),
-    duration = duration(self$get_start_time),
+    duration = duration(self$get_start_time()),
     timeout = private$killed
   )
 }


### PR DESCRIPTION
Fixes r-lib/revdepcheck#81 (but doesn't enable output yet).