### PR TITLE
Show log output also for build stage

### DIFF
--- a/R/background.R
+++ b/R/background.R
@@ -115,7 +115,7 @@ rcc_init <- function(self, private, super, path, args, libpath, repos) {
     path <- normalizePath(path)
   }
 
-  targz <- build_package(path, tmp <- tempfile())
+  targz <- build_package(path, tmp <- tempfile(), quiet = TRUE)
 
   private$description <- desc(path)
   private$path  <- path

--- a/R/build.R
+++ b/R/build.R
@@ -1,7 +1,7 @@
 
 #' @importFrom withr with_dir
 
-build_package <- function(path, tmpdir) {
+build_package <- function(path, tmpdir, quiet) {
 
   dir.create(tmpdir)
   file.copy(path, tmpdir, recursive = TRUE)
@@ -10,7 +10,11 @@ build_package <- function(path, tmpdir) {
   if (file.info(path)$isdir) {
     build_status <- with_dir(
       tmpdir,
-      rcmd_safe("build", basename(path))
+      rcmd_safe(
+        "build",
+        basename(path),
+        block_callback = if (!quiet) block_callback()
+      )
     )
     unlink(file.path(tmpdir, basename(path)), recursive = TRUE)
     report_system_error("Build failed", build_status)

--- a/R/package.R
+++ b/R/package.R
@@ -53,7 +53,7 @@ rcmdcheck <- function(path = ".", quiet = FALSE, args = character(),
     path <- normalizePath(path)
   }
 
-  targz <- build_package(path, tmp <- tempfile())
+  targz <- build_package(path, tmp <- tempfile(), quiet = quiet)
   start_time <- Sys.time()
   desc <- desc(targz)
 


### PR DESCRIPTION
Rationale: Some builds on Travis hang during the build stage, because the vignettes take too long to build. I'm worried why building the package takes longer than 10 minutes, but if there was logging output I'd have found the reasons faster.

How do I add a splitter between the building and the checking output?

Stalled build: https://travis-ci.org/r-prof/jointprof/jobs/388749066#L1513.