### PR TITLE
Enable option to specify custom build args

### DIFF
--- a/R/background.R
+++ b/R/background.R
@@ -57,10 +57,11 @@ rcmdcheck_process <- R6Class(
 
   public = list(
 
-    initialize = function(path = ".", args = character(),
-      libpath = .libPaths(), repos = getOption("repos"))
-      rcc_init(self, private, super, path, check_args = character(),
-               build_args = character(), libpath, repos),
+    initialize = function(path = ".", check_args = character(),
+      build_args = character(), libpath = .libPaths(),
+      repos = getOption("repos"))
+      rcc_init(self, private, super, path, check_args = check_args,
+               build_args = build_args, libpath, repos),
 
     parse_results = function()
       rcc_parse_results(self, private),
@@ -109,8 +110,8 @@ rcmdcheck_process <- R6Class(
 #' @importFrom callr rcmd_process rcmd_process_options
 #' @importFrom desc desc
 
-rcc_init <- function(self, private, super, path, check_args = character(),
-                     build_args = character(), libpath, repos) {
+rcc_init <- function(self, private, super, path, check_args = check_args,
+                     build_args = build_args, libpath, repos) {
 
   if (file.info(path)$isdir) {
     path <- find_package_root_file(path = path)

--- a/R/background.R
+++ b/R/background.R
@@ -116,7 +116,7 @@ rcc_init <- function(self, private, super, path, args, libpath, repos, build_arg
   }
 
   targz <- build_package(path, tmp <- tempfile(), build_args = build_args,
-                         quiet = quiet)
+                         quiet = TRUE)
 
   private$description <- desc(path)
   private$path  <- path

--- a/R/background.R
+++ b/R/background.R
@@ -107,7 +107,7 @@ rcmdcheck_process <- R6Class(
 #' @importFrom callr rcmd_process rcmd_process_options
 #' @importFrom desc desc
 
-rcc_init <- function(self, private, super, path, args, libpath, repos) {
+rcc_init <- function(self, private, super, path, args, libpath, repos, build_args) {
 
   if (file.info(path)$isdir) {
     path <- find_package_root_file(path = path)
@@ -115,7 +115,8 @@ rcc_init <- function(self, private, super, path, args, libpath, repos) {
     path <- normalizePath(path)
   }
 
-  targz <- build_package(path, tmp <- tempfile())
+  targz <- build_package(path, tmp <- tempfile(), build_args = build_args,
+                         quiet = quiet)
 
   private$description <- desc(path)
   private$path  <- path

--- a/R/background.R
+++ b/R/background.R
@@ -28,7 +28,8 @@
 #' * `cp`: A new rcmdcheck_process object.
 #' * `path`: Path to a package tree or a package archive file. This is the
 #'   package to check.
-#' * `args`: Command line arguments to `R CMD check`.
+#' * `check_args`: Command line arguments to `R CMD check`.
+#' * `build_args`: Command line arguments to `R CMD build`.
 #' * `libpath`: The library path to set for the check.
 #' * `repos`: The `repos` option to set for the check.
 #'   This is needed for cyclic dependency checks if you use the
@@ -58,7 +59,8 @@ rcmdcheck_process <- R6Class(
 
     initialize = function(path = ".", args = character(),
       libpath = .libPaths(), repos = getOption("repos"))
-      rcc_init(self, private, super, path, args, libpath, repos),
+      rcc_init(self, private, super, path, check_args = character(),
+               build_args = character(), libpath, repos),
 
     parse_results = function()
       rcc_parse_results(self, private),
@@ -107,7 +109,8 @@ rcmdcheck_process <- R6Class(
 #' @importFrom callr rcmd_process rcmd_process_options
 #' @importFrom desc desc
 
-rcc_init <- function(self, private, super, path, args, libpath, repos, build_args) {
+rcc_init <- function(self, private, super, path, check_args = character(),
+                     build_args = character(), libpath, repos) {
 
   if (file.info(path)$isdir) {
     path <- find_package_root_file(path = path)
@@ -125,7 +128,7 @@ rcc_init <- function(self, private, super, path, args, libpath, repos, build_arg
 
   options <- rcmd_process_options(
     cmd = "check",
-    cmdargs = c(basename(targz), args),
+    cmdargs = c(basename(targz), check_args),
     libpath = libpath,
     repos = repos
   )

--- a/R/build.R
+++ b/R/build.R
@@ -8,9 +8,14 @@ build_package <- function(path, tmpdir, build_args = character(), quiet) {
 
   ## If not a tar.gz, build it. Otherwise just leave it as it is.
   if (file.info(path)$isdir) {
+    if (length(build_args) > 0) {
+      build_args <- append(basename(path), build_args)
+    } else {
+      build_args <- basename(path)
+    }
     build_status <- with_dir(
       tmpdir,
-      rcmd_safe("build", basename(path), cmdargs = build_args,
+      rcmd_safe("build", cmdargs = build_args,
                 block_callback = if (!quiet) block_callback())
     )
     unlink(file.path(tmpdir, basename(path)), recursive = TRUE)

--- a/R/build.R
+++ b/R/build.R
@@ -1,7 +1,7 @@
 
 #' @importFrom withr with_dir
 
-build_package <- function(path, tmpdir) {
+build_package <- function(path, tmpdir, build_args = character(), quiet) {
 
   dir.create(tmpdir)
   file.copy(path, tmpdir, recursive = TRUE)
@@ -10,7 +10,8 @@ build_package <- function(path, tmpdir) {
   if (file.info(path)$isdir) {
     build_status <- with_dir(
       tmpdir,
-      rcmd_safe("build", basename(path))
+      rcmd_safe("build", basename(path), cmdargs = build_args,
+                block_callback = if (!quiet) block_callback())
     )
     unlink(file.path(tmpdir, basename(path)), recursive = TRUE)
     report_system_error("Build failed", build_status)

--- a/R/package.R
+++ b/R/package.R
@@ -12,8 +12,10 @@ NULL
 #'
 #' @param path Path to a package tarball or a directory.
 #' @param quiet Whether to print check output during checking.
-#' @param args Character vector of arguments to pass to
+#' @param check_args Character vector of arguments to pass to
 #'   `R CMD check`.
+#' @param build_args Character vector of arguments to pass to
+#'   `R CMD build`
 #' @param libpath The library path to set for the check.
 #'   The default uses the current library path.
 #' @param repos The `repos` option to set for the check.

--- a/R/package.R
+++ b/R/package.R
@@ -40,7 +40,8 @@ NULL
 #' @importFrom callr rcmd_safe
 #' @importFrom desc desc
 
-rcmdcheck <- function(path = ".", quiet = FALSE, args = character(),
+rcmdcheck <- function(path = ".", quiet = FALSE, check_args = character(),
+                      build_args = character(),
                       libpath = .libPaths(), repos = getOption("repos"),
                       timeout = Inf, error_on =
                         c("never", "error", "warning", "note")) {
@@ -53,7 +54,8 @@ rcmdcheck <- function(path = ".", quiet = FALSE, args = character(),
     path <- normalizePath(path)
   }
 
-  targz <- build_package(path, tmp <- tempfile())
+  targz <- build_package(path, tmp <- tempfile(), build_args = build_args,
+                         quiet = quiet)
   start_time <- Sys.time()
   desc <- desc(targz)
 
@@ -61,7 +63,7 @@ rcmdcheck <- function(path = ".", quiet = FALSE, args = character(),
     dirname(targz),
     do_check(targz,
       package = desc$get("Package")[[1]],
-      args = args,
+      check_args = check_args,
       libpath = libpath,
       repos = repos,
       quiet = quiet,
@@ -91,7 +93,7 @@ rcmdcheck <- function(path = ".", quiet = FALSE, args = character(),
 
 #' @importFrom withr with_envvar
 
-do_check <- function(targz, package, args, libpath, repos,
+do_check <- function(targz, package, check_args, libpath, repos,
                      quiet, timeout) {
 
   profile <- tempfile()
@@ -117,7 +119,7 @@ do_check <- function(targz, package, args, libpath, repos,
     c(R_PROFILE_USER = profile),
     rcmd_safe(
       "check",
-      cmdargs = c(basename(targz), args),
+      cmdargs = c(basename(targz), check_args),
       libpath = libpath,
       user_profile = TRUE,
       repos = repos,

--- a/R/parse.R
+++ b/R/parse.R
@@ -27,7 +27,7 @@ new_rcmdcheck <- function(stdout,
 
       rversion    = parse_rversion(entries),
       platform    = parse_platform(entries),
-      errors      = grep(" ...\\s+ERROR\n",   entries, value = TRUE),
+      errors      = grep("ERROR\n",   entries, value = TRUE),
       warnings    = grep(" ...\\s+WARNING\n", entries, value = TRUE),
       notes       = grep(" ...\\s+NOTE\n",    entries, value = TRUE),
 

--- a/man/compare_checks.Rd
+++ b/man/compare_checks.Rd
@@ -20,4 +20,3 @@ Compare a set of check results to another check result
 \seealso{
 Other check comparisons: \code{\link{compare_to_cran}}
 }
-\concept{check comparisons}

--- a/man/compare_to_cran.Rd
+++ b/man/compare_to_cran.Rd
@@ -21,4 +21,3 @@ Compare a check result to CRAN check results
 \seealso{
 Other check comparisons: \code{\link{compare_checks}}
 }
-\concept{check comparisons}

--- a/man/rcmdcheck.Rd
+++ b/man/rcmdcheck.Rd
@@ -4,19 +4,18 @@
 \name{rcmdcheck}
 \alias{rcmdcheck}
 \alias{rcmdcheck-package}
+\alias{rcmdcheck}
 \title{Run R CMD check from R and Capture Results}
 \usage{
-rcmdcheck(path = ".", quiet = FALSE, args = character(),
-  libpath = .libPaths(), repos = getOption("repos"), timeout = Inf,
-  error_on = c("never", "error", "warning", "note"))
+rcmdcheck(path = ".", quiet = FALSE, check_args = character(),
+  build_args = character(), libpath = .libPaths(),
+  repos = getOption("repos"), timeout = Inf, error_on = c("never",
+  "error", "warning", "note"))
 }
 \arguments{
 \item{path}{Path to a package tarball or a directory.}
 
 \item{quiet}{Whether to print check output during checking.}
-
-\item{args}{Character vector of arguments to pass to
-\code{R CMD check}.}
 
 \item{libpath}{The library path to set for the check.
 The default uses the current library path.}
@@ -37,6 +36,9 @@ no errors are thrown. If \code{"error"}, then only \code{ERROR} failures
 generate errors. If \code{"warning"}, then \code{WARNING} failures generate
 errors as well. If \code{"note"}, then any check failure generated an
 error.}
+
+\item{args}{Character vector of arguments to pass to
+\code{R CMD check}.}
 }
 \value{
 An S3 object (list) with fields \code{errors},
@@ -46,4 +48,6 @@ vectors containing the output for the failed check.
 \description{
 Run R CMD check form R programatically, and capture the results of the
 individual checks.
+
+Run \code{R CMD check} on a package or a directory
 }

--- a/man/rcmdcheck.Rd
+++ b/man/rcmdcheck.Rd
@@ -17,6 +17,12 @@ rcmdcheck(path = ".", quiet = FALSE, check_args = character(),
 
 \item{quiet}{Whether to print check output during checking.}
 
+\item{check_args}{Character vector of arguments to pass to
+\code{R CMD check}.}
+
+\item{build_args}{Character vector of arguments to pass to
+\code{R CMD build}}
+
 \item{libpath}{The library path to set for the check.
 The default uses the current library path.}
 
@@ -36,9 +42,6 @@ no errors are thrown. If \code{"error"}, then only \code{ERROR} failures
 generate errors. If \code{"warning"}, then \code{WARNING} failures generate
 errors as well. If \code{"note"}, then any check failure generated an
 error.}
-
-\item{args}{Character vector of arguments to pass to
-\code{R CMD check}.}
 }
 \value{
 An S3 object (list) with fields \code{errors},

--- a/man/rcmdcheck_process.Rd
+++ b/man/rcmdcheck_process.Rd
@@ -33,7 +33,8 @@ not affected by that.
 \item \code{cp}: A new rcmdcheck_process object.
 \item \code{path}: Path to a package tree or a package archive file. This is the
 package to check.
-\item \code{args}: Command line arguments to \code{R CMD check}.
+\item \code{check_args}: Command line arguments to \code{R CMD check}.
+\item \code{build_args}: Command line arguments to \code{R CMD build}.
 \item \code{libpath}: The library path to set for the check.
 \item \code{repos}: The \code{repos} option to set for the check.
 This is needed for cyclic dependency checks if you use the

--- a/man/rcmdcheck_process.Rd
+++ b/man/rcmdcheck_process.Rd
@@ -20,7 +20,7 @@ Other methods are inherited from \link[callr:rcmd_process]{callr::rcmd_process} 
 Note that you calling the \code{get_output_connection} and
 \code{get_error_connection} method on this is not a good idea, because
 then the stdout and/or stderr of the process will not be collected
-for `parse_results.
+for \code{parse_results()}.
 
 You can still use the \code{read_output_lines()} and \code{read_error_lines()}
 methods to read the standard output and error, \code{parse_results()} is


### PR DESCRIPTION
This PR enables to set custom build args for `R CMD build`. Also it includes showing the log of the build stages using #68.

#### Why is this needed?

If the building of vignettes takes very long, one might want to skip it. For example in `mlr` we check the vignettes in separate build stage on Travis and not during `R CMD check`.
Hence there needs to be an option to set custom build args such as `--no-build-vignettes`.
To do so, the `args` argument was renamed to `check_args` and a new `build_args` argument was added.

