### PR TITLE
Catch test errors in testthat

### DIFF
--- a/R/parse.R
+++ b/R/parse.R
@@ -27,7 +27,7 @@ new_rcmdcheck <- function(stdout,
 
       rversion    = parse_rversion(entries),
       platform    = parse_platform(entries),
-      errors      = grep(" ...\\s+ERROR\n",   entries, value = TRUE),
+      errors      = grep("ERROR\n",   entries, value = TRUE),
       warnings    = grep(" ...\\s+WARNING\n", entries, value = TRUE),
       notes       = grep(" ...\\s+NOTE\n",    entries, value = TRUE),
 


### PR DESCRIPTION
With the less restrictive regex, test errors in testthat are finally catched and passed onto the summary. 

#69 

However, this might also lead to a false "ERROR" count if errors in other steps than "checking tests" appears. See [here](https://travis-ci.org/mlr-org/mlr/jobs/416390736) for an example. 

However, its better to have a false error count than a false positive build.

Probably there are better ways to fix this but it works as a hotfix.

@gaborcsardi It would be great to have this fixed before the CRAN release of [tic](https://github.com/ropenscilabs/tic) to not have to rely on a forked version of `rcmdcheck`. CRAN ETA August/September.

cc @krlmlr 