### PR TITLE
WIP: Pass libpath to build_package()

### DIFF
--- a/R/background.R
+++ b/R/background.R
@@ -122,7 +122,7 @@ rcc_init <- function(self, private, super, path, args, build_args,
   }
 
   targz <- build_package(path, tmp <- tempfile(), build_args = build_args,
-                         quiet = TRUE)
+                         libpath = libpath, quiet = TRUE)
 
   private$description <- desc(path)
   private$path  <- path

--- a/R/package.R
+++ b/R/package.R
@@ -57,7 +57,7 @@ rcmdcheck <- function(path = ".", quiet = FALSE, args = character(),
   }
 
   targz <- build_package(path, tmp <- tempfile(), build_args = build_args,
-                         quiet = quiet)
+                         libpath = libpath, quiet = quiet)
 
   start_time <- Sys.time()
   desc <- desc(targz)


### PR DESCRIPTION
Closes https://github.com/r-lib/callr/issues/78.

The workaround is to ask _callr_ to set `R_LIBS_USER`. This seems necesary so that `R CMD build` can pick up the vignette builder which is needed to build the vignettes (to make sure `R CMD check` doesn't complain). Merely passing `libpath` does not fix the problem.

@gaborcsardi: Please advise.