### PR TITLE
Overwrite files if they exist

### DIFF
--- a/R/build.R
+++ b/R/build.R
@@ -28,7 +28,7 @@ build_package <- function(path, tmpdir, build_args, libpath, quiet) {
     )
 
   } else {
-    file.copy(path, tmpdir)
+    file.copy(path, tmpdir, overwrite = TRUE)
     file.path(tmpdir, basename(path))
   }
 }

--- a/R/package.R
+++ b/R/package.R
@@ -118,10 +118,7 @@ do_check <- function(targz, package, args, libpath, repos,
   on.exit(unlink(profile), add = TRUE)
 
   # if the pkg.Rcheck directory already exists, unlink it
-  check_dir <- paste0(package, ".Rcheck")
-  if (file.exists(check_dir)) {
-    unlink(check_dir, recursive = TRUE)
-  }
+  unlink(paste0(package, ".Rcheck"), recursive = TRUE)
 
   if (!quiet) cat_head("R CMD check")
   res <- with_envvar(

--- a/R/package.R
+++ b/R/package.R
@@ -117,6 +117,12 @@ do_check <- function(targz, package, args, libpath, repos,
   profile <- make_fake_profile(session_output = session_output)
   on.exit(unlink(profile), add = TRUE)
 
+  # if the pkg.Rcheck directory already exists, unlink it
+  check_dir <- paste0(package, ".Rcheck")
+  if (file.exists(check_dir)) {
+    unlink(check_dir, recursive = TRUE)
+  }
+
   if (!quiet) cat_head("R CMD check")
   res <- with_envvar(
     c(R_PROFILE_USER = profile,

--- a/inst/NEWS.md
+++ b/inst/NEWS.md
@@ -1,6 +1,9 @@
 
 # devel
 
+* `rcmdcheck()` now correctly overwrites existing tarballs if they already
+  exist in the check directory (#84 @jimhester).
+
 # 1.3.0
 
 * New `rcmdcheck_process` class to run `R CMD check` in the background.


### PR DESCRIPTION
The default behavior of `file.copy()` is _not_ to overwrite files
(without an error or warning) if they already exist. So if there was
already a built tarball in the check directory it would not be updated.

cc @jennybc