### PR TITLE
Don't overwrite targz with itself

### DIFF
--- a/R/build.R
+++ b/R/build.R
@@ -28,7 +28,8 @@ build_package <- function(path, tmpdir, build_args, libpath, quiet) {
     )
 
   } else {
-    file.copy(path, tmpdir, overwrite = TRUE)
+    path_in_tmpdir <- identical(dirname(normalizePath(path)), normalizePath(tmpdir))
+    file.copy(path, tmpdir, overwrite = !path_in_tmpdir)
     file.path(tmpdir, basename(path))
   }
 }


### PR DESCRIPTION
Closes #87

If the check_dir is unspecified, then it is session temp dir, which is also where the .tar.gz file goes. And it seems that this line has the effect of copying a file onto itself, which deletes the contents.

https://github.com/r-lib/rcmdcheck/blob/6bf1a9462defea33c5aed697e7aa8bc958008877/R/build.R#L31

This restores my ability to use `devtools::check()` in the R Console.

cc @topepo 