### PR TITLE
Fix appveyor

### DIFF
--- a/tests/testthat/test-rcmdcheck.R
+++ b/tests/testthat/test-rcmdcheck.R
@@ -33,7 +33,10 @@ test_that("rcmdcheck works", {
     "Non-standard license specification"
   )
 
-  expect_equal(length(bad1$errors), 0)
+  ## This fails without LaTex, which is not available on Appveyor
+  if (!identical(Sys.getenv("APPVEYOR"), "True")) {
+    expect_equal(length(bad1$errors), 0)
+  }
   expect_true(length(bad1$warnings) >= 1)
   expect_equal(length(bad1$notes), 0)
 


### PR DESCRIPTION
Latex not available, so we need to ignore the failure
coming from failed vignettes.