### PR TITLE
Switch to Authors@R; normalize DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,23 +1,17 @@
 Package: rcmdcheck
 Title: Run 'R CMD check' from 'R' and Capture Results
 Version: 1.3.3.9000
-Author: Gábor Csárdi
-Maintainer: Gábor Csárdi <csardi.gabor@gmail.com>
-Description: Run 'R CMD check' from 'R' and capture the
-    results of the individual checks. Supports running checks in the
-    background, timeouts, pretty printing and comparing check results.
+Authors@R: 
+    person(given = "Gábor",
+           family = "Csárdi",
+           role = "cre",
+           email = "csardi.gabor@gmail.com")
+Description: Run 'R CMD check' from 'R' and capture the results
+    of the individual checks. Supports running checks in the background,
+    timeouts, pretty printing and comparing check results.
 License: MIT + file LICENSE
-LazyData: true
 URL: https://github.com/r-Lib/rcmdcheck#readme
 BugReports: https://github.com/r-Lib/rcmdcheck/issues
-RoxygenNote: 6.1.1
-Roxygen: list(markdown = TRUE)
-Suggests:
-    covr,
-    knitr,
-    mockery,
-    rmarkdown,
-    testthat
 Imports:
     callr (>= 3.1.1.9000),
     cli (>= 1.1.0),
@@ -32,4 +26,13 @@ Imports:
     utils,
     withr,
     xopen
+Suggests:
+    covr,
+    knitr,
+    mockery,
+    rmarkdown,
+    testthat
 Encoding: UTF-8
+LazyData: true
+Roxygen: list(markdown = TRUE)
+RoxygenNote: 6.1.1


### PR DESCRIPTION
This is sort of meta. I'm programmatically pulling all the authors of devtools-verse packages, in an effort to revise the Acknowledgments. And rcmdcheck is beyond my reach because it doesn't use `Authors@R`. I went ahead and normalized DESCRIPTION as well. I did:

``` r
library(desc)

gabor <- person(given = "Gábor", family = "Csárdi",
                email = "csardi.gabor@gmail.com", role = "cre")
desc_set_authors(gabor, normalize = TRUE)
```