### PR TITLE
Try to fix newlines

### DIFF
--- a/R/callback.R
+++ b/R/callback.R
@@ -240,7 +240,7 @@ is_new_check <- function(x) {
 }
 
 simple_callback <- function(top_line = TRUE) {
-  function(x) cat(x)
+  function(x) cat(gsub("[\r\n]+", "\n", x))
 }
 
 detect_callback <- function() {


### PR DESCRIPTION
This seems to fix the doubled newlines on GitHub Actions, without causing problems when R is used in `cmd.exe` or RGui.