### PR TITLE
Better output for multiple (failing) tests with --as-cran

### DIFF
--- a/R/package.R
+++ b/R/package.R
@@ -208,7 +208,7 @@ do_check <- function(targz, package, args, libpath, repos,
       user_profile = TRUE,
       repos = repos,
       stderr = "2>&1",
-      block_callback = if (!quiet) detect_callback(),
+      block_callback = if (!quiet) detect_callback(as_cran = "--as-cran" %in% args),
       spinner = !quiet && should_add_spinner(),
       timeout = timeout,
       fail_on_status = FALSE

--- a/tests/testthat/_snaps/callback.md
+++ b/tests/testthat/_snaps/callback.md
@@ -532,3 +532,41 @@
       [71] ""                                                                              
       [72] "Status: OK"                                                                    
 
+# multiple tests
+
+    Code
+      out
+    Output
+       [1] "  \r-  checking examples ... NONE"                     
+       [2] "\r  \rv  checking for unstated dependencies in ‘tests’"
+       [3] "\r  \r-  checking tests"                               
+       [4] "\r  \r\r  \r-  Running ‘a.R’"                          
+       [5] "\r  \r-  Running ‘b.R’"                                
+       [6] "\r  \r-  Running ‘c.R’"                                
+       [7] "E  Some test files failed"                             
+       [8] "\r  \r   Running the tests in ‘tests/b.R’ failed."     
+       [9] "\r  \r   Complete output:"                             
+      [10] "\r  \r     > stop(\"error\")"                          
+      [11] "\r  \r     Error: error"                               
+      [12] "\r  \r     Execution halted"                           
+      [13] "\r  \rv  checking PDF version of manual"               
+      [14] "\r"                                                    
+
+---
+
+    Code
+      out
+    Output
+       [1] "  \r-  checking examples ... NONE"                     
+       [2] "\r  \rv  checking for unstated dependencies in ‘tests’"
+       [3] "\r  \r-  checking tests"                               
+       [4] "\r  \r\r  \rv  Running ‘a.R’"                          
+       [5] "\r  \rE  Running ‘b.R’"                                
+       [6] "\r  \r   Running the tests in ‘tests/b.R’ failed."     
+       [7] "\r  \r   Complete output:"                             
+       [8] "\r  \r     > stop(\"error\")"                          
+       [9] "\r  \r     Error: error"                               
+      [10] "\r  \r     Execution halted"                           
+      [11] "\r  \rv  checking PDF version of manual"               
+      [12] "\r"                                                    
+

--- a/tests/testthat/fixtures/tests-as-cran.txt
+++ b/tests/testthat/fixtures/tests-as-cran.txt
@@ -1,0 +1,13 @@
+* checking examples ... NONE
+* checking for unstated dependencies in ‘tests’ ... OK
+* checking tests ...
+  Running ‘a.R’
+  Running ‘b.R’
+  Running ‘c.R’
+ ERROR
+Running the tests in ‘tests/b.R’ failed.
+Complete output:
+  > stop("error")
+  Error: error
+  Execution halted
+* checking PDF version of manual ... OK

--- a/tests/testthat/fixtures/tests-not-as-cran.txt
+++ b/tests/testthat/fixtures/tests-not-as-cran.txt
@@ -1,0 +1,12 @@
+* checking examples ... NONE
+* checking for unstated dependencies in ‘tests’ ... OK
+* checking tests ...
+  Running ‘a.R’
+  Running ‘b.R’
+ ERROR
+Running the tests in ‘tests/b.R’ failed.
+Complete output:
+  > stop("error")
+  Error: error
+  Execution halted
+* checking PDF version of manual ... OK

--- a/tests/testthat/test-callback.R
+++ b/tests/testthat/test-callback.R
@@ -127,7 +127,7 @@ test_that("multiple test file run times are measured properly", {
 
 test_that("multi-arch test cases", {
   txt <- list(
-    list("* using log directory 'C:/Users/csard/works/ps.Rcheck'\n", 0.01), 
+    list("* using log directory 'C:/Users/csard/works/ps.Rcheck'\n", 0.01),
     list("* using R version 4.1.1 (2021-08-10)\n", 0.01),
     list("* using platform: x86_64-w64-mingw32 (64-bit)\n", 0.01),
     list("* using session charset: ISO8859-1\n", 0.01),
@@ -173,7 +173,7 @@ test_that("partial comparing line", {
     list("  Comparing ‘test-2.Rout’ to ‘test-2.Rout.save’ ... OK\n", 0),
     list(" OK\n", 0.01),
     list("* checking PDF version of manual ... OK\n", 0.01),
-    list("* DONE\n", 0.01)    
+    list("* DONE\n", 0.01)
   )
 
   out <- capture.output(replay(lines))
@@ -184,7 +184,7 @@ test_that("multiple comparing blocks", {
   txt <- readLines(test_path("fixtures", "checks", "comparing2.txt"))[53:88]
   lines <- lapply(txt, function(x) list(paste0(x, "\n"), 0.001))
   out <- capture.output(replay(lines))
-  expect_snapshot(out)  
+  expect_snapshot(out)
 })
 
 test_that("simple_callback", {
@@ -200,7 +200,7 @@ test_that("detect_callback", {
 
   withr::local_options(cli.dynamic = TRUE)
   expect_equal(detect_callback(), "block")
-  
+
   withr::local_options(cli.dynamic = FALSE)
   expect_equal(detect_callback(), "simple")
 })
@@ -210,4 +210,17 @@ test_that("should_add_spinner", {
   expect_true(should_add_spinner())
   withr::local_options(cli.dynamic = FALSE)
   expect_false(should_add_spinner())
+})
+
+test_that("multiple tests", {
+  txt <- readLines(test_path("fixtures", "tests-as-cran.txt"))
+  lines <- lapply(txt, function(x) list(paste0(x, "\n"), 0.001))
+  cb <- function(...) block_callback(as_cran = TRUE, ...)
+  out <- capture.output(replay(lines, callback = cb))
+  expect_snapshot(out)
+
+  txt <- readLines(test_path("fixtures", "tests-not-as-cran.txt"))
+  lines <- lapply(txt, function(x) list(paste0(x, "\n"), 0.001))
+  out <- capture.output(replay(lines))
+  expect_snapshot(out)
 })


### PR DESCRIPTION
Closes #161.

@hadley 

OK, now the you get this with `--as-cran`:

```
─  checking examples ... NONE (505ms)
✔  checking for unstated dependencies in ‘tests’ ...
─  checking tests (490ms)
─  Running ‘a.R’ (523ms)
─  Running ‘b.R’ (491ms)
─  Running ‘c.R’ (532ms)
E  Some test files failed
   Running the tests in ‘tests/b.R’ failed.
   Complete output:
     > stop("error")
     Error: error
     Execution halted
✔  checking PDF version of manual (6.1s)
```

and this without `--as-cran`:

```
✔  checking for unstated dependencies in ‘tests’ ...
─  checking tests (454ms)
✔  Running ‘a.R’ (508ms)
E  Running ‘b.R’ (503ms)
   Running the tests in ‘tests/b.R’ failed.
   Complete output:
     > stop("error")
     Error: error
     Execution halted
✔  checking PDF version of manual (6.9s)
```

Ideally we would look at the `.Rout` and `.Rout.fail` files, and mark the failed test files in the `--as-cran` case as well, but that would need a bigger rewrite, because right now the output is based on the stdout + stderr of the check process only.