### PR TITLE
Fix check() failing when Rtools not installed

### DIFF
--- a/R/package.R
+++ b/R/package.R
@@ -142,7 +142,7 @@ rcmdcheck <- function(
   # Add pandoc to the PATH, for R CMD build and R CMD check
   if (should_use_rs_pandoc()) local_path(Sys.getenv("RSTUDIO_PANDOC"))
 
-  pkgbuild::without_cache(pkgbuild::local_build_tools())
+  pkgbuild::without_cache(pkgbuild::local_build_tools(required = FALSE))
 
   targz <- build_package(path, check_dir, build_args = build_args,
                          libpath = libpath, quiet = quiet)


### PR DESCRIPTION
pkgbuild::local_build_tools() fails if Rtools is missing on Windows
when `required` argument is TRUE, which is the default. This changes
`required` to FALSE, which shouldn't throw an error, but will load Rtools
if it is available. 

Closes #174.