### PR TITLE
Documentation of `check_dir`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -38,5 +38,5 @@ Suggests:
     webfakes
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.1.2
+RoxygenNote: 7.2.1
 Config/testthat/edition: 3

--- a/R/package.R
+++ b/R/package.R
@@ -77,8 +77,12 @@ NULL
 #'   spaces to delimit arguments like you would in the shell). For example,
 #'   `build_args = c("--force", "--keep-empty-dirs")` is a correct usage and
 #'   `build_args = "--force --keep-empty-dirs"` is incorrect.
-#' @param check_dir Path to a directory where the check is performed. If this is
-#'   `NULL`, then a temporary directory is used, that is cleaned up afterwards.
+#' @param check_dir Path to a directory where the check will be performed. 
+#'   Will be created if needed. 
+#'
+#'   Alternatively, supply `NULL` to perform the check in a temporary directory
+#'   that will be automatically cleaned up when the object returned by `rcmdcheck()`
+#'   is deleted. 
 #' @param libpath The library path to set for the check.
 #'   The default uses the current library path.
 #' @param repos The `repos` option to set for the check.

--- a/R/package.R
+++ b/R/package.R
@@ -78,8 +78,7 @@ NULL
 #'   `build_args = c("--force", "--keep-empty-dirs")` is a correct usage and
 #'   `build_args = "--force --keep-empty-dirs"` is incorrect.
 #' @param check_dir Path to a directory where the check is performed. If this is
-#'   `NULL`, then a temporary directory is used, that is cleaned up when the
-#'   returned object is garbage collected.
+#'   `NULL`, then a temporary directory is used, that is cleaned up afterwards.
 #' @param libpath The library path to set for the check.
 #'   The default uses the current library path.
 #' @param repos The `repos` option to set for the check.

--- a/R/package.R
+++ b/R/package.R
@@ -77,12 +77,13 @@ NULL
 #'   spaces to delimit arguments like you would in the shell). For example,
 #'   `build_args = c("--force", "--keep-empty-dirs")` is a correct usage and
 #'   `build_args = "--force --keep-empty-dirs"` is incorrect.
-#' @param check_dir Path to a directory where the check will be performed. 
-#'   Will be created if needed. 
+#' @param check_dir Path to a directory where the check will be performed.
+#'   The path will be created if needed and is reported in the `checkdir` field
+#'   of the object returned by `rcmdcheck()`.
 #'
-#'   Alternatively, supply `NULL` to perform the check in a temporary directory
-#'   that will be automatically cleaned up when the object returned by `rcmdcheck()`
-#'   is deleted. 
+#'   If `check_dir = NULL` (the default), the check is performed in a temporary
+#'   directory that is automatically cleaned up when the object returned by
+#'   `rcmdcheck()` is deleted.
 #' @param libpath The library path to set for the check.
 #'   The default uses the current library path.
 #' @param repos The `repos` option to set for the check.

--- a/R/package.R
+++ b/R/package.R
@@ -77,9 +77,9 @@ NULL
 #'   spaces to delimit arguments like you would in the shell). For example,
 #'   `build_args = c("--force", "--keep-empty-dirs")` is a correct usage and
 #'   `build_args = "--force --keep-empty-dirs"` is incorrect.
-#' @param check_dir Path to a directory where the check is performed.
-#'   If this is not `NULL`, then a temporary directory is used, that
-#'   is cleaned up when the returned object is garbage collected.
+#' @param check_dir Path to a directory where the check is performed. If this is
+#'   `NULL`, then a temporary directory is used, that is cleaned up when the
+#'   returned object is garbage collected.
 #' @param libpath The library path to set for the check.
 #'   The default uses the current library path.
 #' @param repos The `repos` option to set for the check.

--- a/man/rcmdcheck-config.Rd
+++ b/man/rcmdcheck-config.Rd
@@ -13,8 +13,10 @@ rcmdcheck uses the cli package for much of its output, so you can
 configure the output via cli, see \link[cli:cli-config]{cli::cli-config}.
 
 Package configration is defined in the \code{DESCRIPTION} file of the checked
-package. E.g.:\preformatted{Config/build/clean-inst-doc: FALSE
-}
+package. E.g.:
+
+\if{html}{\out{<div class="sourceCode">}}\preformatted{Config/build/clean-inst-doc: FALSE
+}\if{html}{\out{</div>}}
 }
 \section{Environment variables}{
 \itemize{

--- a/man/rcmdcheck.Rd
+++ b/man/rcmdcheck.Rd
@@ -37,9 +37,9 @@ spaces to delimit arguments like you would in the shell). For example,
 \code{build_args = c("--force", "--keep-empty-dirs")} is a correct usage and
 \code{build_args = "--force --keep-empty-dirs"} is incorrect.}
 
-\item{check_dir}{Path to a directory where the check is performed.
-If this is not \code{NULL}, then a temporary directory is used, that
-is cleaned up when the returned object is garbage collected.}
+\item{check_dir}{Path to a directory where the check is performed. If this is
+\code{NULL}, then a temporary directory is used, that is cleaned up when the
+returned object is garbage collected.}
 
 \item{libpath}{The library path to set for the check.
 The default uses the current library path.}

--- a/man/rcmdcheck.Rd
+++ b/man/rcmdcheck.Rd
@@ -37,8 +37,12 @@ spaces to delimit arguments like you would in the shell). For example,
 \code{build_args = c("--force", "--keep-empty-dirs")} is a correct usage and
 \code{build_args = "--force --keep-empty-dirs"} is incorrect.}
 
-\item{check_dir}{Path to a directory where the check is performed. If this is
-\code{NULL}, then a temporary directory is used, that is cleaned up afterwards.}
+\item{check_dir}{Path to a directory where the check will be performed.
+Will be created if needed.
+
+Alternatively, supply \code{NULL} to perform the check in a temporary directory
+that will be automatically cleaned up when the object returned by \code{rcmdcheck()}
+is deleted.}
 
 \item{libpath}{The library path to set for the check.
 The default uses the current library path.}

--- a/man/rcmdcheck.Rd
+++ b/man/rcmdcheck.Rd
@@ -14,8 +14,7 @@ rcmdcheck(
   libpath = .libPaths(),
   repos = getOption("repos"),
   timeout = Inf,
-  error_on = Sys.getenv("RCMDCHECK_ERROR_ON", c("never", "error", "warning",
-    "note")[1]),
+  error_on = Sys.getenv("RCMDCHECK_ERROR_ON", c("never", "error", "warning", "note")[1]),
   env = character()
 )
 }
@@ -39,7 +38,7 @@ spaces to delimit arguments like you would in the shell). For example,
 \code{build_args = "--force --keep-empty-dirs"} is incorrect.}
 
 \item{check_dir}{Path to a directory where the check is performed.
-If this is not \code{NULL}, then the a temporary directory is used, that
+If this is not \code{NULL}, then a temporary directory is used, that
 is cleaned up when the returned object is garbage collected.}
 
 \item{libpath}{The library path to set for the check.
@@ -85,11 +84,13 @@ process.
 \section{Turning off package checks}{
 Sometimes it is useful to programmatically turn off some checks that
 may report check NOTEs.
-rcmdcehck provides two ways to do this.
+rcmdcheck provides two ways to do this.
 
 First, you may declare in \code{DESCRIPTION} that you don't want to see
-NOTEs that are accepted on CRAN, with this entry:\preformatted{Config/rcmdcheck/ignore-inconsequential-notes: true
-}
+NOTEs that are accepted on CRAN, with this entry:
+
+\if{html}{\out{<div class="sourceCode">}}\preformatted{Config/rcmdcheck/ignore-inconsequential-notes: true
+}\if{html}{\out{</div>}}
 
 Currently, this will make rcmdcheck ignore the following notes:
 \itemize{
@@ -106,7 +107,9 @@ with the list of environment variable settings that rcmdcheck will
 automatically use when checking the package.
 See \link{Startup} for the format of this file.
 
-Here is an example \code{tools/check.env} file:\preformatted{# Report if package size is larger than 10 megabytes
+Here is an example \code{tools/check.env} file:
+
+\if{html}{\out{<div class="sourceCode">}}\preformatted{# Report if package size is larger than 10 megabytes
 _R_CHECK_PKG_SIZES_THRESHOLD_=10
 
 # Do not check Rd cross references
@@ -117,7 +120,7 @@ _R_CHECK_CRAN_INCOMING_NOTE_GNU_MAKE_=false
 
 # Do not check non-ASCII strings in datasets
 _R_CHECK_PACKAGE_DATASETS_SUPPRESS_NOTES_=true
-}
+}\if{html}{\out{</div>}}
 
 See the \href{https://cran.r-project.org/doc/manuals/r-devel/R-ints.html}{"R internals" manual}
 and the \href{https://github.com/wch/r-source}{R source code} for the

--- a/man/rcmdcheck.Rd
+++ b/man/rcmdcheck.Rd
@@ -38,8 +38,7 @@ spaces to delimit arguments like you would in the shell). For example,
 \code{build_args = "--force --keep-empty-dirs"} is incorrect.}
 
 \item{check_dir}{Path to a directory where the check is performed. If this is
-\code{NULL}, then a temporary directory is used, that is cleaned up when the
-returned object is garbage collected.}
+\code{NULL}, then a temporary directory is used, that is cleaned up afterwards.}
 
 \item{libpath}{The library path to set for the check.
 The default uses the current library path.}

--- a/man/rcmdcheck.Rd
+++ b/man/rcmdcheck.Rd
@@ -38,11 +38,12 @@ spaces to delimit arguments like you would in the shell). For example,
 \code{build_args = "--force --keep-empty-dirs"} is incorrect.}
 
 \item{check_dir}{Path to a directory where the check will be performed.
-Will be created if needed.
+The path will be created if needed and is reported in the \code{checkdir} field
+of the object returned by \code{rcmdcheck()}.
 
-Alternatively, supply \code{NULL} to perform the check in a temporary directory
-that will be automatically cleaned up when the object returned by \code{rcmdcheck()}
-is deleted.}
+If \code{check_dir = NULL} (the default), the check is performed in a temporary
+directory that is automatically cleaned up when the object returned by
+\code{rcmdcheck()} is deleted.}
 
 \item{libpath}{The library path to set for the check.
 The default uses the current library path.}

--- a/man/rcmdcheck_process.Rd
+++ b/man/rcmdcheck_process.Rd
@@ -8,12 +8,14 @@ rcmdcheck_process is an R6 class, that extends the
 \link[callr:rcmd_process]{callr::rcmd_process} class (which in turn extends \link[processx:process]{processx::process}.
 }
 \section{Usage}{
-\preformatted{cp <- rcmdcheck_process$new(path = ".", args = character(),
+
+
+\if{html}{\out{<div class="sourceCode">}}\preformatted{cp <- rcmdcheck_process$new(path = ".", args = character(),
          build_args = character(), check_dir = NULL,
          libpath = .libPaths(), repos = getOption("repos"))
 
 cp$parse_results()
-}
+}\if{html}{\out{</div>}}
 
 Other methods are inherited from \link[callr:rcmd_process]{callr::rcmd_process} and
 \link[processx:process]{processx::process}.


### PR DESCRIPTION
This fixes the documentation for argument `check_dir` of `rcmdcheck()`, see r-lib/devtools#2455.