### PR TITLE
use quiet argument

### DIFF
--- a/R/cran.R
+++ b/R/cran.R
@@ -86,7 +86,7 @@ cran_check_results <- function(package,
   urls <- paste0(base, flavours, "/", package, "-00check.txt")
 
   tmp <- paste0(tempfile(), "-", seq_along(urls))
-  download_files(urls, tmp, quiet = FALSE)
+  download_files(urls, tmp, quiet = quiet)
 
   structure(
     lapply(tmp, parse_check),


### PR DESCRIPTION
Previously the quiet argument of cran_check_results was ignored, and download_files always used quiet=FALSE, which I believe is a bug. This commit passes the quiet argument of cran_check_results on to download_files.