### PR TITLE
Don't recycle to zero if parameter is empty

### DIFF
--- a/R/parse.R
+++ b/R/parse.R
@@ -120,10 +120,10 @@ as.data.frame.rcmdcheck <- function(x,
 
   data_frame(
     which = which,
-    platform = x$platform %||% NA_character_,
-    rversion = x$rversion %||% NA_character_,
-    package = x$package %||% NA_character_,
-    version = x$version %||% NA_character_,
+    platform = x$platform %|0|% NA_character_,
+    rversion = x$rversion %|0|% NA_character_,
+    package = x$package %|0|% NA_character_,
+    version = x$version %|0|% NA_character_,
     type = entries$type,
     output = entries$output,
     hash = hash_check(entries$output)

--- a/R/utils.R
+++ b/R/utils.R
@@ -21,6 +21,7 @@ is_count <- function(x) {
 }
 
 `%||%` <- function(l, r) if (is.null(l)) r else l
+`%|0|%` <- function(l, r) if (!length(l)) r else l
 
 #' Alternative to data.frame
 #'

--- a/tests/testthat/test-parse.R
+++ b/tests/testthat/test-parse.R
@@ -73,3 +73,16 @@ test_that("hash_check drops time stamps", {
   expect_equal(hash_check(n1), hash_check(n2))
   expect_equal(hash_check(n1), hash_check(n3))
 })
+
+test_that("results are not recycled to zero", {
+  ok <- parse_check(test_path("REDCapR-ok.log"))
+  fail <- parse_check(test_path("REDCapR-fail.log"))
+
+  # Happens e.g. with `rcmdcheck::cran_check_results()`
+  ok$rversion <- character()
+  fail$rversion <- character()
+
+  # Used to be "+" because of the recycling to zero
+  out <- compare_checks(ok, fail)
+  expect_equal(out$status, "-")
+})


### PR DESCRIPTION
The `rversion` field of `rcmdcheck::cran_check_results()` is `character()`, which causes comparisons to silently succeed because of a recycling to zero issue.