### PR TITLE
Set _R_CHECK_CRAN_INCOMING_NOTE_GNU_MAKE_ to true

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -43,4 +43,4 @@ Config/Needs/website: tidyverse/tidytemplate
 Config/testthat/edition: 3
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.2.1
+RoxygenNote: 7.2.3

--- a/R/env.R
+++ b/R/env.R
@@ -14,8 +14,8 @@ ignore_env_config <- function() {
                    | "_R_CHECK_PKG_SIZES_"                       | FALSE,
     "check cross-references in Rd files"
                    | "_R_CHECK_RD_XREFS_"                        | FALSE,
-    "NOTE if package requires GNU make"
-                   | "_R_CHECK_CRAN_INCOMING_NOTE_GNU_MAKE_"     | FALSE,
+    "ignore NOTE about package requiring GNU make"
+                   | "_R_CHECK_CRAN_INCOMING_NOTE_GNU_MAKE_"     | TRUE,
     "report marked non-ASCII strings in datasets"
                    | "_R_CHECK_PACKAGE_DATASETS_SUPPRESS_NOTES_" | TRUE
   )

--- a/R/package.R
+++ b/R/package.R
@@ -48,7 +48,7 @@ NULL
 #' _R_CHECK_RD_XREFS_=false
 #'
 #' # Do not report if package requires GNU make
-#' _R_CHECK_CRAN_INCOMING_NOTE_GNU_MAKE_=false
+#' _R_CHECK_CRAN_INCOMING_NOTE_GNU_MAKE_=true
 #'
 #' # Do not check non-ASCII strings in datasets
 #' _R_CHECK_PACKAGE_DATASETS_SUPPRESS_NOTES_=true

--- a/man/rcmdcheck.Rd
+++ b/man/rcmdcheck.Rd
@@ -100,7 +100,7 @@ Currently, this will make rcmdcheck ignore the following notes:
 \itemize{
 \item report large package sizes (\verb{_R_CHECK_PKG_SIZES_ = FALSE}),
 \item check cross-references in Rd files (\verb{_R_CHECK_RD_XREFS_ = FALSE}),
-\item NOTE if package requires GNU make (\verb{_R_CHECK_CRAN_INCOMING_NOTE_GNU_MAKE_ = FALSE}),
+\item ignore NOTE about package requiring GNU make (\verb{_R_CHECK_CRAN_INCOMING_NOTE_GNU_MAKE_ = TRUE}),
 \item report marked non-ASCII strings in datasets (\verb{_R_CHECK_PACKAGE_DATASETS_SUPPRESS_NOTES_ = TRUE}).
 }
 
@@ -120,7 +120,7 @@ _R_CHECK_PKG_SIZES_THRESHOLD_=10
 _R_CHECK_RD_XREFS_=false
 
 # Do not report if package requires GNU make
-_R_CHECK_CRAN_INCOMING_NOTE_GNU_MAKE_=false
+_R_CHECK_CRAN_INCOMING_NOTE_GNU_MAKE_=true
 
 # Do not check non-ASCII strings in datasets
 _R_CHECK_PACKAGE_DATASETS_SUPPRESS_NOTES_=true


### PR DESCRIPTION
This is based on my understanding of R source code, and some tests we ran in https://github.com/epiverse-trace/serofoi/pull/134.

https://github.com/wch/r-source/blob/b12ffba7584825d6b11bba8b7dbad084a74c1c20/src/library/tools/R/check.R#L2960

It looks like, in spite of its name, `_R_CHECK_CRAN_INCOMING_NOTE_GNU_MAKE_` will actually trigger the note when set to `FALSE`.

I'm struggling a little bit to make a minimal reprex that will trigger this `NOTE`. Please let me know if you need this and if you have some advice on how to build it.
