### PR TITLE
fix: Improve error handling of non-existent/non-accessible filepaths

### DIFF
--- a/R/build.R
+++ b/R/build.R
@@ -10,7 +10,7 @@ build_package <- function(path, tmpdir, build_args, libpath, quiet) {
   dir.create(tmpdir, recursive = TRUE, showWarnings = FALSE)
   tmpdir <- normalizePath(tmpdir)
 
-  if (file.info(path)$isdir) {
+  if (safecheck_isdir(path)) {
     if (!quiet) cat_head("R CMD build")
 
     desc <- desc(path)

--- a/R/env.R
+++ b/R/env.R
@@ -42,7 +42,7 @@ load_env <- function(path, targz, package, envir = parent.frame()) {
   if (!should_load) return()
 
   env <- NULL
-  if (file.info(path)$isdir) {
+  if (safecheck_isdir(path)) {
     env_path <- file.path(path, "tools", "check.env")
   } else {
     dir.create(tmp <- tempfile())

--- a/R/package.R
+++ b/R/package.R
@@ -130,7 +130,7 @@ rcmdcheck <- function(
 
   error_on <- match.arg(error_on, c("never", "error", "warning", "note"))
 
-  if (file.info(path)$isdir) {
+  if (safecheck_isdir(path)) {
     path <- find_package_root_file(path = path)
   } else {
     path <- normalizePath(path)

--- a/R/utils.R
+++ b/R/utils.R
@@ -216,7 +216,7 @@ data_literal <- function(...) {
 
 safecheck_isdir <- function(path){
   if(!file.exists(path)) stop("path '", path, "' does not exist!")
-  res <- file.info(path)
+  res <- file.info(path, extra_cols = FALSE)
   if(is.na(res$isdir)) stop("path '", path, "' is not readable!")
   res$isdir
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -213,3 +213,10 @@ data_literal <- function(...) {
     colClasses = "character"
   )
 }
+
+safecheck_isdir <- function(path){
+  if(!file.exists(path)) stop("path '", path, "' does not exist!")
+  res <- file.info(path)
+  if(is.na(res$isdir)) stop("path '", path, "' is not readable!")
+  res$isdir
+}

--- a/tests/testthat/test-errors.R
+++ b/tests/testthat/test-errors.R
@@ -73,3 +73,7 @@ test_that("error_on argument", {
   tryCatch(rcmdcheck(), error = function(e) e)
   expect_equal(value, "note")
 })
+
+test_that("error correctly when reading invalid files", {
+  expect_error(rcmdcheck("Invalid file name"), "path 'Invalid file name' does not exist!")
+})


### PR DESCRIPTION
Found a small bug, figured it would be faster to include a fix for it with the report.

Running `rcmdcheck` on a filepath that doesn't exist produces an uninformative error:

```r
> rcmdcheck::rcmdcheck("this path is not a real path!")
## Error in if (file.info(path)$isdir) { : 
##  missing value where TRUE/FALSE needed
```

This is because `file.info(path)` returns all `NA` values if `path` is either non-existent or not readable. I encountered this when I accidentally had a small typo in the path to the package I wanted to test.

This fix wraps the `file.info(path)$isdir` call with some other error handling to produce more informative errors (and potentially allow for other handling / custom error messages later). It also handles the case where the file/directory exists, but isn't readable. Also included a unit test.

New version:

```
> rcmdcheck::rcmdcheck("this path is not a real path!")
## Error in safecheck_isdir(path) : path 'this is a test' does not exist!
```