### PR TITLE
Report rcheck envvars

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,8 @@
 
 * `cran_check_results()` works again.
 
+* `rcmdcheck()` now will print rcheck envvars ([#172](https://github.com/r-lib/rcmdcheck/issues/172))
+
 # rcmdcheck 1.4.0
 
 * `cran_check_results()` now downloads results in parallel, so it is

--- a/NEWS.md
+++ b/NEWS.md
@@ -10,7 +10,7 @@
 
 * `cran_check_results()` works again.
 
-* `rcmdcheck()` now will print rcheck envvars ([#172](https://github.com/r-lib/rcmdcheck/issues/172))
+* `rcmdcheck()` now will print relevant environment variables (#172, @tanho63)
 
 # rcmdcheck 1.4.0
 

--- a/R/package.R
+++ b/R/package.R
@@ -227,9 +227,41 @@ do_check <- function(
   }
 
   # user supplied env vars take precedence
-  if (length(env)) chkenv[names(env)] <- env
+  if (length(env)) {
+    chkenv[names(env)] <- env
+  }
 
-  if (!quiet) cat_head("R CMD check")
+  if (!quiet) {
+    cat_head("R CMD check")
+    cat_line()
+    all_vars <- Sys.getenv()
+    rchk_vars <- all_vars[
+      grep("_R_CHECK|NOT_CRAN|RCMDCHECK|R_TESTS", names(all_vars))
+    ]
+    rchk_vars[names(env)] <- env
+    if (length(rchk_vars) == 0) {
+      cli::cat_bullet(
+        "No R CMD check env vars set",
+        col = "darkgrey",
+        bullet = "line",
+        bullet_col = "darkgrey"
+      )
+    }
+    if (length(rchk_vars) > 0) {
+      cli::cat_bullet(
+        "R CMD check env vars set:",
+        col = "darkgrey",
+        bullet = "line",
+        bullet_col = "darkgrey"
+      )
+      cli::cat_bullet(
+        paste0(format(names(rchk_vars)), " = ", unname(rchk_vars)),
+        col = "darkgrey"
+      )
+      cat_line()
+    }
+  }
+
   callback <- if (!quiet) detect_callback(as_cran = "--as-cran" %in% args)
   res <- rcmd_safe(
     "check",

--- a/R/package.R
+++ b/R/package.R
@@ -143,7 +143,9 @@ rcmdcheck <- function(
   }
 
   # Add pandoc to the PATH, for R CMD build and R CMD check
-  if (should_use_rs_pandoc()) local_path(Sys.getenv("RSTUDIO_PANDOC"))
+  if (should_use_rs_pandoc()) {
+    local_path(Sys.getenv("RSTUDIO_PANDOC"))
+  }
 
   pkgbuild::without_cache(pkgbuild::local_build_tools())
 
@@ -175,7 +177,9 @@ rcmdcheck <- function(
 
   on.exit(unlink(out$session_info, recursive = TRUE), add = TRUE)
 
-  if (isTRUE(out$timeout)) message("R CMD check timed out")
+  if (isTRUE(out$timeout)) {
+    message("R CMD check timed out")
+  }
 
   res <- new_rcmdcheck(
     stdout = out$result$stdout,
@@ -188,7 +192,9 @@ rcmdcheck <- function(
   )
 
   # Automatically delete temporary files when this object disappears
-  if (cleanup) res$cleaner <- auto_clean(check_dir)
+  if (cleanup) {
+    res$cleaner <- auto_clean(check_dir)
+  }
 
   handle_error_on(res, error_on)
 
@@ -239,17 +245,10 @@ do_check <- function(
       grep("_R_CHECK|NOT_CRAN|RCMDCHECK|R_TESTS", names(all_vars))
     ]
     rchk_vars[names(env)] <- env
-    if (length(rchk_vars) == 0) {
-      cli::cat_bullet(
-        "No R CMD check env vars set",
-        col = "darkgrey",
-        bullet = "line",
-        bullet_col = "darkgrey"
-      )
-    }
+
     if (length(rchk_vars) > 0) {
       cli::cat_bullet(
-        "R CMD check env vars set:",
+        "With:",
         col = "darkgrey",
         bullet = "line",
         bullet_col = "darkgrey"
@@ -278,7 +277,9 @@ do_check <- function(
   )
 
   # To print an incomplete line on timeout or crash
-  if (!is.null(callback) && (res$timeout || res$status != 0)) callback("\n")
+  if (!is.null(callback) && (res$timeout || res$status != 0)) {
+    callback("\n")
+  }
 
   # Non-zero status is an error, the check process failed
   # R CMD check returns 1 for installation errors, we don't want to error


### PR DESCRIPTION
Closes #172 - prints `_R_CHECK_*`, `NOT_CRAN`, and other related rcmdcheck envvars.

```
R> rcmdcheck::rcmdcheck("tests/testthat/bad1")
── R CMD build ───────────────────────────────────────────────────────────────────────────────
pdflatex not found! Not building PDF manual.
✔  checking for file ‘.../DESCRIPTION’ ...
─  preparing ‘badpackage’:
✔  checking DESCRIPTION meta-information
─  installing the package to build vignettes
✔  creating vignettes (1.4s)
─  checking for LF line-endings in source and make files and shell scripts (351ms)
─  checking for empty or unneeded directories
─  building ‘badpackage_1.0.0.tar.gz’
   
── R CMD check ───────────────────────────────────────────────────────────────────────────────

─ R CMD check env vars set:
• _R_CHECK_PKG_SIZES_THRESHOLD_ = 142
```

```
R> rcmdcheck::rcmdcheck("tests/testthat/bad2")
── R CMD build ───────────────────────────────────────────────────────────────────────────────
pdflatex not found! Not building PDF manual.
✔  checking for file ‘.../DESCRIPTION’ ...
─  preparing ‘badpackage’:
✔  checking DESCRIPTION meta-information ...
─  checking for LF line-endings in source and make files and shell scripts
─  checking for empty or unneeded directories
─  building ‘badpackage_1.0.0.tar.gz’
   
── R CMD check ───────────────────────────────────────────────────────────────────────────────

─ No R CMD check env vars set
─  using log directory ‘/tmp/RtmptQxJYO/file111243a95c5f9/badpackage.Rcheck’
```

