### PR TITLE
Fix typo in rcmdcheck parameter description

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ rcmdcheck("path/to/R/package")
 ```
 
 Call `rcmdcheck()` on a source R package `.tar.gz` file, or on a folder
-containing your R package. Supply `quiet = FALSE` if you want to omit
+containing your R package. Supply `quiet = TRUE` if you want to omit
 the output. The result of the check is returned, in a list with elements
 `errors`, `warnings`, and `notes`. Each element is a character vector,
 and one element of the character vectors is a single failure.


### PR DESCRIPTION
Corrected the description of the 'quiet' parameter in rcmdcheck usage, which should be set to TRUE to omit the output.