### PR TITLE
fix profile used before assignment in background check setup

### DIFF
--- a/R/background.R
+++ b/R/background.R
@@ -172,8 +172,8 @@ rcc_init <- function(
   # probably inside test cases of some package
   if (Sys.getenv("R_TESTS", "") == "") {
     private$session_output <- tempfile()
-    private$tempfiles <- c(private$session_output, profile)
     profile <- make_fake_profile(package, private$session_output, libdir)
+    private$tempfiles <- c(private$session_output, profile)
     chkenv["R_TESTS"] <- profile
   }
 


### PR DESCRIPTION
private$tempfiles <- c(private$session_output, profile) ran one line before profile <- make_fake_profile(...), so profile resolved to stats::profile and the temp-file cleanup list received a function object instead of the generated path. Assign profile first. Mirrors the ordering already used in R/package.R.

Found during my large https://github.com/sims1253/ry audit